### PR TITLE
Run only one instance of health-check.sh and not infinite

### DIFF
--- a/src/health-check.sh
+++ b/src/health-check.sh
@@ -5,6 +5,13 @@ CONFIGTYPE="${CONFIGTYPE:-"fhem.cfg"}"
 TELNETPORT="${TELNETPORT:-7072}"
 STATE=0
 
+RUNNING_INSTANCES=$(pgrep -f "/bin/sh -c /health-check.sh" | wc -l)
+
+if [ ${RUNNING_INSTANCES} -gt "1" ]; then
+  echo "Instance already running, aborting another one"
+  exit 1
+fi
+
 if [ "${CONFIGTYPE}" != "configDB" ] && [ -s ${FHEM_DIR}/${CONFIGTYPE} ] && [ -z "$(cat ${FHEM_DIR}/${CONFIGTYPE} | grep -P "^define .* telnet ${TELNETPORT}")" ]; then
   TELNETPORT="$(cat ${FHEM_DIR}/${CONFIGTYPE} | grep -P '^define .* telnet ' | head -1 | cut -d ' ' -f 4)"
 


### PR DESCRIPTION
Made the health-check aware if another instance is already running.

