### PR TITLE
Added integrationtests and build full and minimal image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  test_build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -134,7 +134,7 @@ jobs:
             IMAGE_LAYER_PYTHON_EXT=1
             IMAGE_LAYER_NODEJS=1
             IMAGE_LAYER_NODEJS_EXT=1
-
+            
       - name: Inspect and run integration tests
         run: |
           docker image inspect fhem:${{ steps.buildVars.outputs.VARIANT }}
@@ -151,6 +151,81 @@ jobs:
           echo -e "\n"
           docker exec ${CONTAINER} /bin/bash -c 'prove --recurse /opt/fhem/t/FHEM' || true
           docker container rm $CONTAINER --force --volumes
+
+  published_build:
+    runs-on: ubuntu-latest
+    needs: test_build
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get latest svn revision from remote
+        id: svnRemote
+        run: echo "::set-output name=LAST_SVN_REVISION::$( svn info --show-item revision https://svn.fhem.de/fhem/trunk )"
+
+      - name: Get cached fhem 
+        id: cache-fhem
+        uses: actions/cache@v2
+        with:
+          path: ./src/fhem/trunk
+          key: ${{ runner.os }}-fhemsvn-${{ steps.svnRemote.outputs.LAST_SVN_REVISION }}
+          restore-keys: |
+            ${{ runner.os }}-fhemsvn-
+
+      - name: get svn vars
+        id: svnVars
+        run: |
+          echo "::set-output name=FHEM_REVISION_LATEST::$( cd ./src/fhem/trunk; svn info --show-item last-changed-revision)"
+          echo "::set-output name=FHEM_VERSION::$( cd ./src/fhem/trunk; svn ls "^/tags" https://svn.fhem.de/fhem/ | grep "FHEM_" | sort | tail -n 1 | cut -d / -f 1 | cut -d " " -f 1 |cut -d _ -f 2- | sed s/_/./g )"
+
+      - name: prepare some vars
+        id: buildVars
+        run: |
+          VARIANT_FHEM="${{ steps.svnVars.outputs.FHEM_VERSION }}-s${{ steps.svnVars.outputs.FHEM_REVISION_LATEST }}"
+          VARIANT_IMAGE="${{ steps.gitVars.outputs.IMAGE_VERSION }}-${{ steps.gitVars.outputs.BRANCH }}"
+          echo "::set-output name=VARIANT::$(echo "${VARIANT_FHEM}_${VARIANT_IMAGE}")"
+          echo "::set-output name=VARIANT_IMAGE::$(echo "$VARIANT_IMAGE")"
+          echo "::set-output name=VARIANT_FHEM::$(echo "$VARIANT_FHEM")"
+          echo "::set-output name=BUILD_DATE::$(  date --iso-8601=seconds --utc )"
+          # detect rolling branch
+          if [[ ${{ steps.gitVars.outputs.BRANCH }} == "master" ]]; then
+          echo "::set-output name=TAG_ROLLING::latest"
+          else
+          echo "::set-output name=TAG_ROLLING::$( echo "${{ steps.gitVars.outputs.BRANCH }}" | tr '[A-Z]' '[a-z]' )"
+          fi
+
+      - name: Check variables
+        run: |
+          echo FHEM_REVISION_LATEST: ${{ steps.svnVars.outputs.FHEM_REVISION_LATEST }}
+          echo FHEM_VERSION: ${{ steps.svnVars.outputs.FHEM_VERSION }}
+          echo IMAGE_VERSION: ${{ steps.gitVars.outputs.IMAGE_VERSION }}
+          echo BUILD_DATE: ${{ steps.buildVars.outputs.BUILD_DATE }}
+          echo BRANCH: ${{ steps.gitVars.outputs.BRANCH }}
+          echo VARIANT: ${{ steps.buildVars.outputs.VARIANT }}
+          echo VARIANT_IMAGE: ${{ steps.buildVars.outputs.VARIANT_IMAGE }}
+          echo VARIANT_FHEM: ${{ steps.buildVars.outputs.VARIANT_FHEM }}
+          echo VAROLLING_TAG: ${{ steps.buildVars.outputs.TAG_ROLLING }}
+          
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           if [[ ${{ steps.gitVars.outputs.BRANCH }} == "master" ]]; then
           echo "::set-output name=TAG_ROLLING::latest"
           else
-          echo "::set-output name=TAG_ROLLING::$( echo "${{ steps.gitVars.outputs.BRANCH }}" )"
+          echo "::set-output name=TAG_ROLLING::$( echo "${{ steps.gitVars.outputs.BRANCH }}" | tr '[A-Z]' '[a-z]') )"
           fi
 
       - name: Check variables
@@ -111,6 +111,7 @@ jobs:
 
       - name: Build and test full blown amd64 
         uses: docker/build-push-action@v2
+        id: docker_build
         with:
           context: .
           load: true  
@@ -144,26 +145,33 @@ jobs:
           docker image inspect fhem:${{ steps.buildVars.outputs.VARIANT }}
           ./scripts/test-integration.sh;
 
+      - name: Run build in unittests
+        run: |
+          CONTAINER=$( docker run -d -ti --health-interval=60s --health-timeout=10s --health-start-period=150s --health-retries=5 -e CPAN_PKGS=Test2::Suite ${{ steps.docker_build.outputs.digest }} ) 
+          sleep 5;
+          docker exec ${CONTAINER} /bin/bash -c 'prove /opt/fhem/t/FHEM/*'
+
       - name: Login to GitHub Container Registry
+        if: ${{ secrets.CR_PAT }}
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Build and push cross compiled full blown image
+      - name: Build and push cross compiled full blown image on supported platforms
+        if: ${{ secrets.CR_PAT }}
         uses: docker/build-push-action@v2
         with:
           context: .
           load: false  
           file: ./Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,
-          # platforms: linux/arm/v6,linux/arm/v7,linux/amd64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
-            ghcr.io/sidey79/fhem-experimental:latest
+            ghcr.io/${{ github.repository_owner }}/fhem-experimental:${{ steps.buildVars.outputs.TAG_ROLLING }}
 
           build-args: |
             PLATFORM=linux
@@ -183,6 +191,39 @@ jobs:
             IMAGE_LAYER_PYTHON_EXT=1
             IMAGE_LAYER_NODEJS=1
             IMAGE_LAYER_NODEJS_EXT=1
+            L_DESCR="A full blown Docker image for FHEM house automation system, based on Debian Buster."
 
+      - name: Build and push cross compiled base image on supported platforms
+        if: ${{ secrets.CR_PAT }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          load: false  
+          file: ./Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/fhem-minimal-experimental:${{ steps.buildVars.outputs.TAG_ROLLING }}
 
-
+          build-args: |
+            PLATFORM=linux
+            BUILD_DATE=${{ steps.buildVars.outputs.BUILD_DATE }}
+            TAG=${{ steps.buildVars.outputs.VARIANT }}
+            TAG_ROLLING=${{ steps.buildVars.outputs.TAG_ROLLING }}
+            IMAGE_VERSION=${{ steps.buildVars.outputs.VARIANT }}
+            IMAGE_VCS_REF=${{ github.sha }}
+            FHEM_VERSION=${{ steps.buildVars.outputs.VARIANT_FHEM }}
+            VCS_REF=${{ steps.svnVars.outputs.FHEM_REVISION_LATEST }}
+            IMAGE_LAYER_SYS_EXT=0
+            IMAGE_LAYER_PERL_EXT=1
+            IMAGE_LAYER_DEV=0
+            IMAGE_LAYER_PERL_CPAN=1
+            IMAGE_LAYER_PERL_CPAN_EXT=0
+            IMAGE_LAYER_PYTHON=0
+            IMAGE_LAYER_PYTHON_EXT=0
+            IMAGE_LAYER_NODEJS=0
+            IMAGE_LAYER_NODEJS_EXT=0
+            L_DESCR="A minimal (perl) Docker image for FHEM house automation system, based on Debian Buster."
+            

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,42 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Build and push
+      - name: Build and test amd64
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          load: true  
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: fhem:${{ steps.buildVars.outputs.VARIANT }}
+          build-args: |
+            PLATFORM=linux
+            BUILD_DATE=${{ steps.buildVars.outputs.BUILD_DATE }}
+            TAG=${{ steps.buildVars.outputs.VARIANT }}
+            TAG_ROLLING=${{ steps.buildVars.outputs.TAG_ROLLING }}
+            IMAGE_VERSION=${{ steps.buildVars.outputs.VARIANT }}
+            IMAGE_VCS_REF=${{ github.sha }}
+            FHEM_VERSION=${{ steps.buildVars.outputs.VARIANT_FHEM }}
+            VCS_REF=${{ steps.svnVars.outputs.FHEM_REVISION_LATEST }}
+            IMAGE_LAYER_SYS_EXT=0
+            IMAGE_LAYER_PERL_EXT=1
+            IMAGE_LAYER_DEV=0
+            IMAGE_LAYER_PERL_CPAN=1
+            IMAGE_LAYER_PERL_CPAN_EXT=0
+            IMAGE_LAYER_PYTHON=0
+            IMAGE_LAYER_PYTHON_EXT=0
+            IMAGE_LAYER_NODEJS=0
+            IMAGE_LAYER_NODEJS_EXT=0
+
+      - name: Inspect and run integration tests
+        run: |
+          docker image inspect fhem:${{ steps.buildVars.outputs.VARIANT }}
+          ./scripts/test-integration.sh;
+
+      - name: Build and push cross
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,7 @@ jobs:
           do sleep 1;
           echo -n "."; 
           done;
+          echo -e "\n"
           docker exec ${CONTAINER} /bin/bash -c 'prove --recurse /opt/fhem/t/FHEM' || true
           docker container rm $CONTAINER --force --volumes
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Build and Test
 
 # Controls when the action will run. 
 on:
@@ -149,7 +149,7 @@ jobs:
         run: |
           CONTAINER=$( docker run -d -ti --health-interval=60s --health-timeout=10s --health-start-period=150s --health-retries=5 -e CPAN_PKGS=Test2::Suite fhem:${{ steps.buildVars.outputs.VARIANT }} ) 
           sleep 5;
-          docker exec ${CONTAINER} /bin/bash -c 'prove /opt/fhem/t/FHEM/*'
+          docker exec ${CONTAINER} /bin/bash -c 'prove /opt/fhem/t/FHEM/'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-fhemsvn-
 
-      - name: Checkout fhem from svn
+      - name: Update or checkout fhem from svn
         if: steps.cache-fhem.outputs.cache-hit != 'true'
-        run: svn co https://svn.fhem.de/fhem/trunk ./src/fhem/trunk >/dev/null;
+        run: svn update ./src/fhem/trunk || svn co https://svn.fhem.de/fhem/trunk ./src/fhem/trunk >/dev/null;
 
       - name: Update fhem from svn
         if: steps.cache-fhem.outputs.cache-hit == 'true'
@@ -144,6 +144,13 @@ jobs:
           docker image inspect fhem:${{ steps.buildVars.outputs.VARIANT }}
           ./scripts/test-integration.sh;
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
       - name: Build and push cross
         uses: docker/build-push-action@v2
         with:
@@ -152,10 +159,12 @@ jobs:
           file: ./Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,
           # platforms: linux/arm/v6,linux/arm/v7,linux/amd64
-          push: false
+          push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          tags: fhem:${{ steps.buildVars.outputs.VARIANT }}
+          tags: |
+            ghcr.io/sidey79/fhem-experimental:latest
+
           build-args: |
             PLATFORM=linux
             BUILD_DATE=${{ steps.buildVars.outputs.BUILD_DATE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           CONTAINER=$( docker run -d -ti --health-interval=60s --health-timeout=10s --health-start-period=150s --health-retries=5 -e CPAN_PKGS=Test2::Suite fhem:${{ steps.buildVars.outputs.VARIANT }} ) 
           sleep 5;
-          docker exec ${CONTAINER} /bin/bash -c 'prove /opt/fhem/t/FHEM/'
+          docker exec ${CONTAINER} /bin/bash -c '/bin/bash -c 'prove --recurse /opt/fhem/t/FHEM'' || true
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           if [[ ${{ steps.gitVars.outputs.BRANCH }} == "master" ]]; then
           echo "::set-output name=TAG_ROLLING::latest"
           else
-          echo "::set-output name=TAG_ROLLING::$( echo "${{ steps.gitVars.outputs.BRANCH }}" | tr '[A-Z]' '[a-z]') )"
+          echo "::set-output name=TAG_ROLLING::$( echo "${{ steps.gitVars.outputs.BRANCH }}" | tr '[A-Z]' '[a-z]' )"
           fi
 
       - name: Check variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,6 @@ jobs:
           docker exec ${CONTAINER} /bin/bash -c 'prove /opt/fhem/t/FHEM/*'
 
       - name: Login to GitHub Container Registry
-        if: ${{ secrets.CR_PAT }}
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
@@ -160,7 +159,6 @@ jobs:
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push cross compiled full blown image on supported platforms
-        if: ${{ secrets.CR_PAT }}
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -194,7 +192,6 @@ jobs:
             L_DESCR="A full blown Docker image for FHEM house automation system, based on Debian Buster."
 
       - name: Build and push cross compiled base image on supported platforms
-        if: ${{ secrets.CR_PAT }}
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Run build in unittests
         run: |
-          CONTAINER=$( docker run -d -ti --health-interval=60s --health-timeout=10s --health-start-period=150s --health-retries=5 -e CPAN_PKGS=Test2::Suite ${{ steps.docker_build.outputs.digest }} ) 
+          CONTAINER=$( docker run -d -ti --health-interval=60s --health-timeout=10s --health-start-period=150s --health-retries=5 -e CPAN_PKGS=Test2::Suite fhem:${{ steps.buildVars.outputs.VARIANT }} ) 
           sleep 5;
           docker exec ${CONTAINER} /bin/bash -c 'prove /opt/fhem/t/FHEM/*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           echo "::set-output name=IMAGE_VERSION::$( git describe --tags --dirty --match "v[0-9]*")"
         id: gitVars
 
-      - name: Get latest svn revision from remote
+      - name: Get latest svn revision from remote server
         id: svnRemote
         run: echo "::set-output name=LAST_SVN_REVISION::$( svn info --show-item revision https://svn.fhem.de/fhem/trunk )"
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Update or checkout fhem from svn
         if: steps.cache-fhem.outputs.cache-hit != 'true'
-        run: svn update ./src/fhem/trunk || svn co https://svn.fhem.de/fhem/trunk ./src/fhem/trunk >/dev/null;
+        run: svn update ./src/fhem/trunk/  || svn co https://svn.fhem.de/fhem/trunk ./src/fhem/trunk;
 
       - name: get svn vars
         id: svnVars
@@ -95,14 +95,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      
+      # cache disabled, becuse the Dockerfile has currently no cache compatible layout
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildx-
 
       - name: Build for test full blown amd64 
         uses: docker/build-push-action@v2
@@ -113,8 +114,9 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # cache disabled, becuse the Dockerfile has currently no cache compatible layout
+          # cache-from: type=local,src=/tmp/.buildx-cache
+          # cache-to: type=local,dest=/tmp/.buildx-cache
           tags: fhem:${{ steps.buildVars.outputs.VARIANT }}
           build-args: |
             PLATFORM=linux
@@ -134,7 +136,7 @@ jobs:
             IMAGE_LAYER_PYTHON_EXT=1
             IMAGE_LAYER_NODEJS=1
             IMAGE_LAYER_NODEJS_EXT=1
-            
+
       - name: Inspect and run integration tests
         run: |
           docker image inspect fhem:${{ steps.buildVars.outputs.VARIANT }}
@@ -162,6 +164,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Get git vars
+        shell: bash
+        run: |
+          echo "::set-output name=BRANCH::$(echo "${GITHUB_REF#refs/*/}")"
+          echo "::set-output name=IMAGE_VERSION::$( git describe --tags --dirty --match "v[0-9]*")"
+        id: gitVars
 
       - name: Get latest svn revision from remote
         id: svnRemote
@@ -218,14 +227,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      
+      # cache disabled, becuse the Dockerfile has currently no cache compatible layout
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
+      #     restore-keys: |
+      #     ${{ runner.os }}-buildx-
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
@@ -242,8 +252,9 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # cache disabled, becuse the Dockerfile has currently no cache compatible layout
+          # cache-from: type=local,src=/tmp/.buildx-cache
+          # cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             ghcr.io/${{ github.repository_owner }}/fhem-experimental:${{ steps.buildVars.outputs.TAG_ROLLING }}
 
@@ -275,8 +286,9 @@ jobs:
           file: ./Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # cache disabled, becuse the Dockerfile has currently no cache compatible layout
+          # cache-from: type=local,src=/tmp/.buildx-cache
+          # cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             ghcr.io/${{ github.repository_owner }}/fhem-minimal-experimental:${{ steps.buildVars.outputs.TAG_ROLLING }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Build and test amd64
+      - name: Build and test full blown amd64 
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -129,15 +129,15 @@ jobs:
             IMAGE_VCS_REF=${{ github.sha }}
             FHEM_VERSION=${{ steps.buildVars.outputs.VARIANT_FHEM }}
             VCS_REF=${{ steps.svnVars.outputs.FHEM_REVISION_LATEST }}
-            IMAGE_LAYER_SYS_EXT=0
+            IMAGE_LAYER_SYS_EXT=1
             IMAGE_LAYER_PERL_EXT=1
-            IMAGE_LAYER_DEV=0
+            IMAGE_LAYER_DEV=1
             IMAGE_LAYER_PERL_CPAN=1
-            IMAGE_LAYER_PERL_CPAN_EXT=0
-            IMAGE_LAYER_PYTHON=0
-            IMAGE_LAYER_PYTHON_EXT=0
-            IMAGE_LAYER_NODEJS=0
-            IMAGE_LAYER_NODEJS_EXT=0
+            IMAGE_LAYER_PERL_CPAN_EXT=1
+            IMAGE_LAYER_PYTHON=1
+            IMAGE_LAYER_PYTHON_EXT=1
+            IMAGE_LAYER_NODEJS=1
+            IMAGE_LAYER_NODEJS_EXT=1
 
       - name: Inspect and run integration tests
         run: |
@@ -151,7 +151,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Build and push cross
+      - name: Build and push cross compiled full blown image
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -174,15 +174,15 @@ jobs:
             IMAGE_VCS_REF=${{ github.sha }}
             FHEM_VERSION=${{ steps.buildVars.outputs.VARIANT_FHEM }}
             VCS_REF=${{ steps.svnVars.outputs.FHEM_REVISION_LATEST }}
-            IMAGE_LAYER_SYS_EXT=0
+            IMAGE_LAYER_SYS_EXT=1
             IMAGE_LAYER_PERL_EXT=1
-            IMAGE_LAYER_DEV=0
+            IMAGE_LAYER_DEV=1
             IMAGE_LAYER_PERL_CPAN=1
-            IMAGE_LAYER_PERL_CPAN_EXT=0
-            IMAGE_LAYER_PYTHON=0
-            IMAGE_LAYER_PYTHON_EXT=0
-            IMAGE_LAYER_NODEJS=0
-            IMAGE_LAYER_NODEJS_EXT=0
+            IMAGE_LAYER_PERL_CPAN_EXT=1
+            IMAGE_LAYER_PYTHON=1
+            IMAGE_LAYER_PYTHON_EXT=1
+            IMAGE_LAYER_NODEJS=1
+            IMAGE_LAYER_NODEJS_EXT=1
 
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Build and test full blown amd64 
+      - name: Build for test full blown amd64 
         uses: docker/build-push-action@v2
         id: docker_build
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,6 @@ jobs:
         if: steps.cache-fhem.outputs.cache-hit != 'true'
         run: svn update ./src/fhem/trunk || svn co https://svn.fhem.de/fhem/trunk ./src/fhem/trunk >/dev/null;
 
-      - name: Update fhem from svn
-        if: steps.cache-fhem.outputs.cache-hit == 'true'
-        run: svn update
-        working-directory: ./src/fhem/trunk
-
       - name: get svn vars
         id: svnVars
         run: |
@@ -147,9 +142,14 @@ jobs:
 
       - name: Run build in unittests
         run: |
-          CONTAINER=$( docker run -d -ti --health-interval=60s --health-timeout=10s --health-start-period=150s --health-retries=5 -e CPAN_PKGS=Test2::Suite fhem:${{ steps.buildVars.outputs.VARIANT }} ) 
-          sleep 5;
-          docker exec ${CONTAINER} /bin/bash -c '/bin/bash -c 'prove --recurse /opt/fhem/t/FHEM'' || true
+          CONTAINER=$(docker run -d -ti --health-interval=10s --health-timeout=8s --health-start-period=10s --health-retries=5 -e CPAN_PKGS=Test2::Suite fhem:${{ steps.buildVars.outputs.VARIANT }} )
+          sleep 15;
+          until [ "$(/usr/bin/docker inspect -f {{.State.Health.Status}} $CONTAINER)" == "healthy" ]; 
+          do sleep 1;
+          echo -n "."; 
+          done;
+          docker exec ${CONTAINER} /bin/bash -c 'prove --recurse /opt/fhem/t/FHEM' || true
+          docker container rm $CONTAINER --force --volumes
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
@@ -189,7 +189,7 @@ jobs:
             IMAGE_LAYER_PYTHON_EXT=1
             IMAGE_LAYER_NODEJS=1
             IMAGE_LAYER_NODEJS_EXT=1
-            L_DESCR="A full blown Docker image for FHEM house automation system, based on Debian Buster."
+            L_DESCR=A full blown Docker image for FHEM house automation system, based on Debian Buster.
 
       - name: Build and push cross compiled base image on supported platforms
         uses: docker/build-push-action@v2
@@ -222,5 +222,5 @@ jobs:
             IMAGE_LAYER_PYTHON_EXT=0
             IMAGE_LAYER_NODEJS=0
             IMAGE_LAYER_NODEJS_EXT=0
-            L_DESCR="A minimal (perl) Docker image for FHEM house automation system, based on Debian Buster."
+            L_DESCR=A minimal (perl) Docker image for FHEM house automation system, based on Debian Buster.
             

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ARG L_USAGE="https://github.com/fhem/fhem-docker/blob/${IMAGE_VCS_REF}/README.md
 ARG L_VCS_URL="https://github.com/fhem/fhem-docker/"
 ARG L_VENDOR="Julian Pawlowski"
 ARG L_LICENSES="MIT"
-ARG L_TITLE="fhem-${ARCH}_${PLATFORM}"
+ARG L_TITLE="fhem-${TARGETPLATFORM}"
 ARG L_DESCR="A basic Docker image for FHEM house automation system, based on Debian Buster."
 
 ARG L_AUTHORS_FHEM="https://fhem.de/MAINTAINER.txt"

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ ENV LANG=en_US.UTF-8 \
    TIMEOUT=10 \
    CONFIGTYPE=fhem.cfg
 
-# Install base environment
+# Install base environment, cache is invalidated here, because we set a BUILD_DATE Variable which changes every run.
 COPY ./src/qemu-* /usr/bin/
 COPY src/entry.sh /entry.sh
 COPY src/ssh_known_hosts.txt /ssh_known_hosts.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG NPM_PKGS=""
 
 # Re-usable variables during build
 ARG L_AUTHORS="Julian Pawlowski (Forum.fhem.de:@loredo, Twitter:@loredo)"
-ARG L_URL="https://hub.docker.com/r/fhem/fhem-${TARGETARCH}_${PLATFORM}"
+ARG L_URL="https://hub.docker.com/r/fhem/fhem-${TARGETPLATFORM}"
 ARG L_USAGE="https://github.com/fhem/fhem-docker/blob/${IMAGE_VCS_REF}/README.md"
 ARG L_VCS_URL="https://github.com/fhem/fhem-docker/"
 ARG L_VENDOR="Julian Pawlowski"
@@ -429,7 +429,7 @@ RUN if ( [ "${NPM_PKGS}" != "" ] || [ "${IMAGE_LAYER_NODEJS}" != "0" ] || [ "${I
     ; fi
 
 # Add FHEM app layer
-# Note: Manual checkout is required if build is not run by Travis:
+# Note: Manual checkout is required if build is not run by Github Actions workflow:
 #   svn co https://svn.fhem.de/fhem/trunk ./src/fhem/trunk
 COPY src/fhem/trunk/fhem/ /fhem/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -401,7 +401,7 @@ RUN if [ "${PIP_PKGS}" != "" ] || [ "${IMAGE_LAYER_PYTHON}" != "0" ] || [ "${IMA
 
 # Add nodejs app layer
 RUN if ( [ "${NPM_PKGS}" != "" ] || [ "${IMAGE_LAYER_NODEJS}" != "0" ] || [ "${IMAGE_LAYER_NODEJS_EXT}" != "0" ] ) && ( [ "${ARCH}" == "AMD64" ] || [ "${ARCH}" == "ARMv7" ] || [ "${ARCH}" == "ARM64v8" ]  ||  \
-         [ ${TARGETPLATFORM} == 'linux/amd64' ] || [ ${TARGETPLATFORM} == 'linux/arm/v7' ] || [ ${TARGETPLATFORM} == 'linux/arm64' ] ) ; then \
+         [ "${TARGETPLATFORM}" == 'linux/amd64' ] || [ "${TARGETPLATFORM}" == 'linux/arm/v7' ] || [ "${TARGETPLATFORM}" == 'linux/arm64' ] ) ; then \
       LC_ALL=C curl --retry 3 --retry-connrefused --retry-delay 2 -fsSL https://deb.nodesource.com/setup_14.x | LC_ALL=C bash - \
       && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends \
            nodejs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -400,8 +400,7 @@ RUN if [ "${PIP_PKGS}" != "" ] || [ "${IMAGE_LAYER_PYTHON}" != "0" ] || [ "${IMA
     ; fi
 
 # Add nodejs app layer
-RUN if ( [ "${NPM_PKGS}" != "" ] || [ "${IMAGE_LAYER_NODEJS}" != "0" ] || [ "${IMAGE_LAYER_NODEJS_EXT}" != "0" ] ) && ( [ "${ARCH}" == "AMD64" ] || [ "${ARCH}" == "ARMv7" ] || [ "${ARCH}" == "ARM64v8" ]  ||  \
-         [ "${TARGETPLATFORM}" == 'linux/amd64' ] || [ "${TARGETPLATFORM}" == 'linux/arm/v7' ] || [ "${TARGETPLATFORM}" == 'linux/arm64' ] ) ; then \
+RUN if ( [ "${NPM_PKGS}" != "" ] || [ "${IMAGE_LAYER_NODEJS}" != "0" ] || [ "${IMAGE_LAYER_NODEJS_EXT}" != "0" ] ) ; then \
       LC_ALL=C curl --retry 3 --retry-connrefused --retry-delay 2 -fsSL https://deb.nodesource.com/setup_14.x | LC_ALL=C bash - \
       && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends \
            nodejs \


### PR DESCRIPTION
Workflow

Added two stages:
- test_build
   - runs in fhem includes unittest  
   - runs integrationtest script
  
- published_build
   - Builds full blown image on supported platforms
   - Builds a minimal image with less layers for all platforms
   - Publishes the images into github container registry for testing purpose

build.sh 
   - script adapted to dockerx 
   - installs dockerx as docker plugin for user which calls the scipt
 
Dockerfile 
   - removed ARCH evaulation for node layer. This must be done outside the job, like in the workflow step or a script